### PR TITLE
style.css: Make cursor pointer on executable code

### DIFF
--- a/try-js_of_ocaml/style.css
+++ b/try-js_of_ocaml/style.css
@@ -142,7 +142,7 @@ dl dt {
     margin-top: 10px;
     margin-right: 10px;
     padding: 7px;
- }
+}
 
 #buttons {
     text-align: center;
@@ -152,4 +152,8 @@ dl dt {
     position: absolute;
     top: 2%;
     float: left
- }
+}
+
+code {
+    cursor: pointer;
+} 


### PR DESCRIPTION
* Added `cursor: pointer` to < code > elements so that code that is to be executed doesn't have the same cursor that other text in the page has.